### PR TITLE
Add appointment booking link to contact page

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -13,6 +13,12 @@ I'm always eager to connect with fellow researchers, collaborators, or anyone in
 **Affiliation:** Brandeis University  
 **Email:** [abuzarmahmood@gmail.com](mailto:abuzarmahmood@gmail.com)
 
+## Schedule a Meeting
+
+Want to discuss research, collaboration opportunities, or have questions? Book a time that works for you:
+
+📅 [Schedule an Appointment](https://calendar.app.google/CDLQzyhk5AAdeGaZ7)
+
 ## Connect With Me
 
 - [LinkedIn](https://www.linkedin.com/in/abuzarmahmood)


### PR DESCRIPTION
## Summary

This PR adds a Google Calendar appointment booking link to the contact page, making it easier for visitors to schedule meetings.

## Changes

- Added a new 'Schedule a Meeting' section on the contact page
- Included the Google Calendar appointment link: https://calendar.app.google/CDLQzyhk5AAdeGaZ7
- Positioned the section prominently above the social media links for easy visibility

## Testing

The changes have been made to the markdown file and will render correctly on the Jekyll site.

Fixes #44