### PR TITLE
Add Brandeis Math Bio Seminar talk

### DIFF
--- a/_talks/2025-10-08-math-bio-seminar.md
+++ b/_talks/2025-10-08-math-bio-seminar.md
@@ -1,0 +1,13 @@
+---
+title: "Brandeis Math Bio Seminar - Abuzar Mahmood"
+collection: talks
+type: "Seminar"
+permalink: /talks/2025-10-08-math-bio-seminar
+venue: "Brandeis University, Math Bio Seminar"
+date: 2025-10-08
+location: "Waltham, MA"
+---
+
+Presented research at the Brandeis Math Bio Seminar on October 8th, 2025.
+
+[Watch the seminar on YouTube](https://youtu.be/8glMuorr-UY?si=IGLiYglKxk2v9-h7)


### PR DESCRIPTION
This PR adds the Brandeis Math Bio Seminar presentation from October 8th, 2025.

- Created new talk entry in _talks directory
- Included YouTube link to the recorded seminar
- Follows existing talk file format and conventions

Closes #48