### PR TITLE
Update news page to make 2026 publications more exciting

### DIFF
--- a/_pages/news.md
+++ b/_pages/news.md
@@ -13,11 +13,17 @@ Stay informed about my latest research developments, publications, presentations
 
 ## Recent Highlights
 
-### 2026
+### 2026 🎉
 
 **Publications**  
+🚀 **Exciting news!** Two major publications released in 2026!
 - Mahmood, Abuzar, et al. “Sensory and Palatability Coding of Taste Stimuli in Cortex Involves Dynamic and Asymmetric Cortico-Amygdalar Interactions.” Journal of Neurophysiology, Jan. 2026, p. jn.00503.2025. [[Link](https://doi.org/10.1152/jn.00503.2025)]
 - Mahmood, A. (2026). pytau: A Python package for streamlined changepoint model analysis in neuroscience. Journal of Open Source Software, 11(117), 8509. [[Link](https://doi.org/10.21105/joss.08509)]
+
+<div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 20px; border-radius: 10px; color: white; margin: 20px 0; text-align: center;">
+  <strong style="font-size: 1.2em;">🌟 2026 is off to an amazing start!</strong><br>
+  Check out these groundbreaking publications in neuroscience and open source software!
+</div>
 
 ### 2025
 


### PR DESCRIPTION
## Summary
This PR addresses issue #68 by updating the news page to make the statement on 2026 publications more exciting.

### Changes Made:
- Added emoji (🎉, 🚀, 🌟) and excitement markers to the 2026 section
- Added an introductory line: "Exciting news! Two major publications released in 2026!"
- Added a visual highlight box with a gradient background to draw attention to the 2026 publications

### Testing
- No tests were added as this is a documentation/content change only
- The changes follow the existing style of the news page (similar visual elements are used elsewhere in the file)

Closes #68

@abuzarmahmood can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f9fa2ee154f24b99a4c5458f284f6e16)