### PR TITLE
Add missing University of Missouri awards to detailed CV (Fix #80)

### DIFF
--- a/_pages/detailed_cv.md
+++ b/_pages/detailed_cv.md
@@ -209,6 +209,18 @@ author_profile: true
 | Computational Neuroscience Training Fellowship, NIH | 2017–19 |
 | Academic Hardware Grant, NVIDIA | 2018 |
 | Award for Academic Distinction, University of Missouri | 2017 |
+| Clifford W. Tompson Scholarship, Department of Physics, University of Missouri | 2016–2017 |
+| Curator's Grant in Aid Award, International Center, University of Missouri | 2015–2017 |
+| Col. Arthur C. Allen Scholarship, College of Arts and Science, University of Missouri | 2015–2017 |
+| Dean's List, College of Arts and Science, University of Missouri | 2013–2017 |
+| International Merit Scholarship, International Center, University of Missouri | 2013–2017 |
+| Junior Scholarship Award, Honors College, University of Missouri | 2016 |
+| Life Sciences Undergraduate Research Opportunity, University of Missouri | 2016 |
+| Rosemary Dishman Scholarship, Department of Physics, University of Missouri | 2015 |
+| Sophomore Scholarship Award, Honors College, University of Missouri | 2015 |
+| Undergraduate Research Travel Award, Office of Undergraduate Research, University of Missouri | 2015 |
+| Newell S. Gingrich Undergraduate Scholarship, Department of Physics, University of Missouri | 2014 |
+| Paul E. Basye Scholarship, Department of Physics, University of Missouri | 2014 |
 | First Place, Undergraduate Poster Competition, Missouri LS Week | 2016, 2017 |
 | Summer Research Fellowship, University of Missouri | 2016 |
 | Distinction, University of Missouri Cardiovascular Day XXII Poster Competition | 2015 |


### PR DESCRIPTION
## Summary

This PR fixes issue #80 by adding the missing University of Missouri awards to the detailed CV.

## Changes Made

Added the following awards that were found in the attached PDF (Mahmood_CV_1_3_24b.pdf) but were missing from the detailed_cv.md file:

- Clifford W. Tompson Scholarship, Department of Physics, University of Missouri (2016-2017)
- Curator's Grant in Aid Award, International Center, University of Missouri (2015-2017)
- Col. Arthur C. Allen Scholarship, College of Arts and Science, University of Missouri (2015-2017)
- Dean's List, College of Arts and Science, University of Missouri (2013-2017)
- International Merit Scholarship, International Center, University of Missouri (2013-2017)
- Junior Scholarship Award, Honors College, University of Missouri (2016)
- Life Sciences Undergraduate Research Opportunity, University of Missouri (2016)
- Rosemary Dishman Scholarship, Department of Physics, University of Missouri (2015)
- Sophomore Scholarship Award, Honors College, University of Missouri (2015)
- Undergraduate Research Travel Award, Office of Undergraduate Research, University of Missouri (2015)
- Newell S. Gingrich Undergraduate Scholarship, Department of Physics, University of Missouri (2014)
- Paul E. Basye Scholarship, Department of Physics, University of Missouri (2014)

These awards are now listed in the "Support, Fellowships, and Awards" section of the detailed CV.

## Verification

The changes were made by extracting text from the PDF attached to the issue and comparing it with the existing awards in the detailed_cv.md file. The missing awards were identified and added in their correct chronological order.