### PR TITLE
Update link to PDF CV on homepage to point to detailed CV

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -20,7 +20,7 @@ My current work aims to further elucidate these interactions by investigating th
 
 I'm always eager to connect with fellow neuroscientists, data scientists, or anyone interested in the fascinating world of neural dynamics. Feel free to [reach out](/contact/) or explore my [projects](/projects/) and [publications](/publications/).
 
-You can also view my [CV](/detailed_cv/) or download a (fairly recent) [PDF version](/files/Mahmood_CV_1-12-26.pdf).
+You can also view my [CV](/detailed_cv/) or download a (fairly recent) [PDF version](/files/Mahmood_detailed_CV.pdf).
 
 
 Research Interests


### PR DESCRIPTION
## Summary
Update the link to the PDF CV on the homepage (about.md) to point to the automatically generated detailed CV PDF (`/files/Mahmood_detailed_CV.pdf`) instead of the old manual CV PDF (`/files/Mahmood_CV_1-12-26.pdf`).

## Changes
- Changed the PDF link in `_pages/about.md` from `/files/Mahmood_CV_1-12-26.pdf` to `/files/Mahmood_detailed_CV.pdf`

## Related Issue
Fixes #86