### PR TITLE
Fix issue #88: Add link to tutorial series to bayesian and time-series modelling repo teachables

### DIFF
--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -59,9 +59,8 @@ Stay tuned for these exciting topics:
 - **Neural Dynamics Visualized**: Interactive visualizations of taste-responsive neural populations
 - **Machine Learning in Neuroscience**: A practical guide to implementing deep learning models for neural data analysis
 - **The Attractor Network Hypothesis**: Evidence for and against attractor dynamics in sensory processing
-- **[Tutorial Series](/blog/)**: Step-by-step guides to Bayesian and time-series modelling techniques
-
-[View Tutorial Series on GitHub](https://github.com/abuzarmahmood/teachables)
+- **Tutorial Series**: Step-by-step guides to Bayesian and time-series modelling techniques
+  - [View Tutorial Series on GitHub](https://github.com/abuzarmahmood/teachables)
 
 ## Join the Conversation
 

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -59,7 +59,9 @@ Stay tuned for these exciting topics:
 - **Neural Dynamics Visualized**: Interactive visualizations of taste-responsive neural populations
 - **Machine Learning in Neuroscience**: A practical guide to implementing deep learning models for neural data analysis
 - **The Attractor Network Hypothesis**: Evidence for and against attractor dynamics in sensory processing
-- **Tutorial Series**: Step-by-step guides to advanced spike sorting techniques
+- **[Tutorial Series](/blog/)**: Step-by-step guides to Bayesian and time-series modelling techniques
+
+[View Tutorial Series on GitHub](https://github.com/abuzarmahmood/teachables)
 
 ## Join the Conversation
 


### PR DESCRIPTION
## Summary

Fixed issue #88 by updating the blog page to link to the Bayesian and time-series modelling tutorial series repo instead of spike-sorting tutorials.

### Changes Made

- Updated "Tutorial Series" in the "Upcoming Content" section to link to Bayesian and time-series modelling
- Added a direct link to the teachables repo: https://github.com/abuzarmahmood/teachables

### Testing

- No new tests required - this is a documentation/content change only

Fixes #88