### PR TITLE
Update Brandeis postdoc to end in March 2026 and add Visiting Research Scholar role

### DIFF
--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -28,9 +28,10 @@ Education
 
 Research experience
 ======
-* <b>Postdoctoral Researcher</b>, Brandeis University, MA	<span style="float:right;">Starting April 2023</span>
+* <b>Postdoctoral Researcher</b>, Brandeis University, MA	<span style="float:right;">Apr 2023 – Mar 2026</span>
   * <u>Project</u>: Dynamics of information flow during the evoked taste response
   * <u>Research Summary</u> : My doctoral research showed that cortical and amygdalar activity is coordinated for taste processing, however, the dynamics of directionality of this influence are not known. Furthermore, cortex receives simultaneous input from both amygdalar and thalamic pathways, however neither the dynamics of thalamo-cortical interaction, nor the interplay between limbic and thalamic input on cortex have not been investigated. This project proposes to investigate the dynamics of influence of the limbic and thalamic pathways on activity in the gustatory cortex and investigate the role of feedback projections from the gustatory cortex to the basolateral amygdala and gustatory thalamus. 
+* <b>Visiting Research Scholar</b>, Brandeis University, MA	<span style="float:right;">Mar 2026 – Present</span> 
 * <b>Ph.D. Researcher</b>, Brandeis University, MA	<span style="float:right;">2017 – Feb 2023</span>
   * <u>Thesis Advisor:</u> Donald B. Katz
   * <u>Thesis Title:</u> Multi-region Coordination for Taste Processing in the Rodent Brain

--- a/_pages/detailed_cv.md
+++ b/_pages/detailed_cv.md
@@ -32,9 +32,11 @@ author_profile: true
 **Postdoctoral Research Fellow**, Tufts Medical Center, MA <span style="float:right;">July 2023 – Present</span>
 - Project: Bioinformatics analysis of the effect of AT2R activation on cardiomyopathy in obesity and diabetes
 
-**Postdoctoral Fellow**, Brandeis University, MA <span style="float:right;">Nov 2023 – Present</span>
+**Postdoctoral Fellow**, Brandeis University, MA <span style="float:right;">Nov 2023 – Mar 2026</span>
 - Swartz Foundation Computational Neuroscience Postdoctoral Fellow (2023–25)
 - Project: Dynamics of information flow during the evoked taste response
+
+**Visiting Research Scholar**, Brandeis University, MA <span style="float:right;">Mar 2026 – Present</span>
 
 **Postdoctoral Associate**, Brandeis University, MA <span style="float:right;">Mar 2023 – Nov 2023</span>
 - Project: Dynamics of information flow during the evoked taste response

--- a/_pages/detailed_cv.md
+++ b/_pages/detailed_cv.md
@@ -32,11 +32,11 @@ author_profile: true
 **Postdoctoral Research Fellow**, Tufts Medical Center, MA <span style="float:right;">July 2023 – Present</span>
 - Project: Bioinformatics analysis of the effect of AT2R activation on cardiomyopathy in obesity and diabetes
 
+**Visiting Research Scholar**, Brandeis University, MA <span style="float:right;">Mar 2026 – Present</span>
+
 **Postdoctoral Fellow**, Brandeis University, MA <span style="float:right;">Nov 2023 – Mar 2026</span>
 - Swartz Foundation Computational Neuroscience Postdoctoral Fellow (2023–25)
 - Project: Dynamics of information flow during the evoked taste response
-
-**Visiting Research Scholar**, Brandeis University, MA <span style="float:right;">Mar 2026 – Present</span>
 
 **Postdoctoral Associate**, Brandeis University, MA <span style="float:right;">Mar 2023 – Nov 2023</span>
 - Project: Dynamics of information flow during the evoked taste response


### PR DESCRIPTION
## Summary

This PR addresses issue #94 by making the following changes:

1. **Updated Brandeis postdoc end date**: Changed the end date from "Present" to "March 2026" in both `_pages/cv.md` and `_pages/detailed_cv.md`

2. **Added new role**: Added "Visiting Research Scholar, Brandeis University, MA" starting in March 2026 in both CV files

### Changes made:
- `_pages/cv.md`: Updated postdoctoral researcher dates to Apr 2023 – Mar 2026, added new Visiting Research Scholar role starting Mar 2026
- `_pages/detailed_cv.md`: Updated postdoctoral fellow dates to Nov 2023 – Mar 2026, added new Visiting Research Scholar role starting Mar 2026

Fixes #94

@abuzarmahmood can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b82c0771-4ca7-4223-ba3e-0e6c169c2a09)