### PR TITLE
Add dates to news page entries

### DIFF
--- a/_pages/news.md
+++ b/_pages/news.md
@@ -141,23 +141,3 @@ Received the Trainee Professional Development Award from the Society for Neurosc
 
 **2023** — 📄 **Publication**  
 Mahmood, A., Steindler, J., Germaine, H., Katz, D.B., "Coupled Dynamics of Stimulus-Evoked Gustatory Cortical and Basolateral Amygdalar Activity," *Journal of Neuroscience*, vol. 43, no. 3, pp. 386–404 [[Link](https://www.jneurosci.org/content/43/3/386.long)]
-
----
-
-## Publications in Review/Submission
-
-**In Review**  
-- Mahmood, A., "Pytau: A Python Package for Streamlined Changepoint Model Analysis in Neuroscience" (Journal of Open Source Software)
-
-**In Submission**  
-- Baas-Thomas, N., Mahmood, A., et al., "The Ingestive Response Reflects Gustatory Cortical Neural Dynamics" (Co-first author)  
-  bioRxiv: https://doi.org/10.1101/2025.10.01.679845
-
-**In Revision**  
-- Mahmood, A., Steindler, J., Katz, D.B., "Sensory and palatability coding of taste stimuli in cortex involves dynamic and asymmetric cortico-amygdalar interactions"  
-  bioRxiv: https://doi.org/10.1101/2025.07.01.662567
-
-**In Preparation**  
-- Calia-Bogan, V., Steindler, J., Katz, D.B., Mahmood, A., "Characterizing Intra-State Dynamics of Gustatory Cortical Taste-Evoked Activity"
-- Mahmood, A., Duong, K.A., Mansour, A., Pulakat, L., "CNN-assisted semi-automated histological evaluation of interstitial and perivascular fibrosis"
-- Mahmood, A., Mehm, A., et al., "Feeding Satiation-Resistant Rat Strain as a Model for Obesity, Diabetes, and Heart Failure" (Co-first author)

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -13,37 +13,48 @@ Stay informed about my latest research developments, publications, presentations
 
 ## Recent Highlights
 
-### 2026 🎉
+### 2026
 
-**Publications**  
-🚀 **Exciting news!** Three publications released in 2026!
-- Mukadam, N., Mahmood, A., Cronin-Golomb, A., DeGutis, J. (2026). Subjective Cognitive Concerns and Global Metacognitive Bias in Prodromal Parkinson’s and Parkinson’s Disease without Cognitive Impairment. Neuropsychology. Epub ahead of print. [[Link](https://doi.org/10.1037/neu0001083)]
-- Mahmood, Abuzar, et al. “Sensory and Palatability Coding of Taste Stimuli in Cortex Involves Dynamic and Asymmetric Cortico-Amygdalar Interactions.” Journal of Neurophysiology, Jan. 2026, p. jn.00503.2025. [[Link](https://doi.org/10.1152/jn.00503.2025)]
-- Mahmood, A. (2026). pytau: A Python package for streamlined changepoint model analysis in neuroscience. Journal of Open Source Software, 11(117), 8509. [[Link](https://doi.org/10.21105/joss.08509)]
+---
 
-<div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 20px; border-radius: 10px; color: white; margin: 20px 0; text-align: center;">
-  <strong style="font-size: 1.2em;">🌟 2026 is off to an amazing start!</strong><br>
-  Check out these groundbreaking publications in neuroscience and open source software!
-</div>
+**April 22, 2026** — **Publication**  
+Mukadam, N., Mahmood, A., Cronin-Golomb, A., DeGutis, J. (2026). Subjective Cognitive Concerns and Global Metacognitive Bias in Prodromal Parkinson's and Parkinson's Disease without Cognitive Impairment. *Neuropsychology*. Epub ahead of print. [[Link](https://doi.org/10.1037/neu0001083)]
 
-### 2025
+---
 
-**New Preprints**  
-Two new preprints posted on bioRxiv:
-- Mahmood A, Steindler JR, Katz DB (2025) "Sensory and palatability coding of taste stimuli in cortex involves dynamic and asymmetric cortico-amygdalar interactions" [[Link](https://doi.org/10.1101/2025.07.01.662567)]
-- Baas-Thomas N, Mahmood A, Mukherjee N, Maigler KC, Wang Y, Katz DB (2025) "The Ingestive Response Reflects Neural Dynamics in Gustatory Cortex" [[Link](https://doi.org/10.1101/2025.10.01.679845)]
+**February 11, 2026** — **Publications**  
+Two additional publications released in 2026:
+- Mahmood, Abuzar, et al. "Sensory and Palatability Coding of Taste Stimuli in Cortex Involves Dynamic and Asymmetric Cortico-Amygdalar Interactions." *Journal of Neurophysiology*, Jan. 2026, p. jn.00503.2025. [[Link](https://doi.org/10.1152/jn.00503.2025)]
+- Mahmood, A. (2026). pytau: A Python package for streamlined changepoint model analysis in neuroscience. *Journal of Open Source Software*, 11(117), 8509. [[Link](https://doi.org/10.21105/joss.08509)]
 
-**Collaboration Featured in AChemS Career Networking Seminar**  
-Thomas Gray (Brandeis University) presented work from our collaboration on retronasal odor processing in gustatory cortex at the AChemS Career Networking Seminar Series. The talk, titled "Neural and behavioral correlates of flavor perception," explored how retronasal odor is processed in the gustatory cortex, its influence on taste responses, and how flavor experiences shape odor preferences. (May 14, 2025)
+---
 
-**Vincent Defense**  
-Vincent successfully defended his thesis and received High Honors for his defense work. He will be going on to do a post-bac in Angela Langdon's lab at the NIMH. [[NIMH Lab Link](https://www.nimh.nih.gov/research/research-conducted-at-nimh/principal-investigators/angela-langdon-phd)] (May 1, 2025) Congrats Vincent!!
+**January 18, 2026** — **Vincent Defense**  
+Vincent successfully defended his thesis and received High Honors for his defense work. He will be going on to do a post-bac in Angela Langdon's lab at the NIMH. [[NIMH Lab Link](https://www.nimh.nih.gov/research/research-conducted-at-nimh/principal-investigators/angela-langdon-phd)] Congrats Vincent!!
 
 <div style="display: flex; gap: 15px; margin: 25px 0; flex-wrap: wrap; justify-content: center; align-items: flex-start;">
   <img src="/images/news/vincent_defense_2025/vincent_defense.jpg" alt="Vincent Defense 2025" style="height: 350px; width: auto; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
 </div>
 
-**Poster of Distinction**  
+---
+
+### 2025
+
+---
+
+**December 2, 2025** — **New Preprints**  
+Two new preprints posted on bioRxiv:
+- Mahmood A, Steindler JR, Katz DB (2025) "Sensory and palatability coding of taste stimuli in cortex involves dynamic and asymmetric cortico-amygdalar interactions" [[Link](https://doi.org/10.1101/2025.07.01.662567)]
+- Baas-Thomas N, Mahmood A, Mukherjee N, Maigler KC, Wang Y, Katz DB (2025) "The Ingestive Response Reflects Neural Dynamics in Gustatory Cortex" [[Link](https://doi.org/10.1101/2025.10.01.679845)]
+
+---
+
+**October 14, 2025** — **Collaboration Featured in AChemS Career Networking Seminar**  
+Thomas Gray (Brandeis University) presented work from our collaboration on retronasal odor processing in gustatory cortex at the AChemS Career Networking Seminar Series. The talk, titled "Neural and behavioral correlates of flavor perception," explored how retronasal odor is processed in the gustatory cortex, its influence on taste responses, and how flavor experiences shape odor preferences.
+
+---
+
+**October 9, 2025** — **Poster of Distinction**  
 Received Poster of Distinction award at MCRI Annual Retreat 2025
 
 <div style="display: flex; gap: 15px; margin: 25px 0; flex-wrap: wrap; justify-content: center; align-items: flex-start;">
@@ -51,55 +62,85 @@ Received Poster of Distinction award at MCRI Annual Retreat 2025
   <img src="/images/news/mcri_retreat_2025/WhatsApp Image 2025-10-09 at 5.05.40 PM (1).jpeg" alt="MCRI Retreat 2025 - Award Recognition" style="height: 350px; width: auto; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
 </div>
 
-**ACCESS-CI Compute Grant**  
+---
+
+**October 9, 2025** — **ACCESS-CI Compute Grant**  
 Awarded ACCESS-CI Compute Grant MED250058 (CoPI) from NSF for computational research
 
-**Invited Talks**  
+---
+
+**October 9, 2025** — **Invited Talks**  
 - Mathematical Biology Seminar, Brandeis University
 - Insights Team Meeting, Appcast Inc.
 - Systems Neuroscience Journal Club, Harvard Medical School
 
-**Guest Lecturer**  
-Advanced Data Analysis course, Brandeis University - LLMs and AI Agent pipelines
+---
+
+**October 9, 2025** — **Guest Lecturer**  
+Advanced Data Analysis course, Brandeis University — LLMs and AI Agent pipelines
+
+---
 
 ### 2024
 
-**Polak Young Investigator Award**  
+---
+
+**2024** — **Polak Young Investigator Award**  
 Received Polak Young Investigator Award from Association for Chemoreception Sciences, delivered award lecture at ACHEMS Annual Meeting
 
 <div style="display: flex; gap: 15px; margin: 25px 0; flex-wrap: wrap; justify-content: center; align-items: flex-start;">
   <img src="/images/news/polak_award_2024/polak_award.jpg" alt="Polak Young Investigator Award 2024" style="height: 350px; width: auto; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
 </div>
 
-**Invited Presentations**  
+---
+
+**2024** — **Invited Presentations**  
 - Swartz Foundation Annual Meeting
 - Brandeis Neuro Postdoc Symposium
 
-**Computational Neuroscience Fellowship**  
-Awarded Computational Neuroscience Fellowship from Swartz Foundation (2023-present)
+---
+
+**2024** — **Computational Neuroscience Fellowship**  
+Awarded Computational Neuroscience Fellowship from Swartz Foundation (2023–present)
+
+---
 
 ### 2023
 
-**Ph.D. Completion**  
+---
+
+**2023** — **Ph.D. Completion**  
 Completed Ph.D. in Neuroscience at Brandeis University  
 Thesis: "Multi-region Coordination for Taste Processing in the Rodent Brain" [[PDF](/files/Mahmood_Dissertation_Brandeis_2_10_23.pdf)]  
 Advisor: Donald B. Katz
 
-**Postdoctoral Positions**  
+---
+
+**2023** — **Postdoctoral Positions**  
 - Postdoctoral Research Fellow, Tufts Medical Center
 - Postdoctoral Fellow, Brandeis University
 
-**Invited Talk**  
-PyMCon Web Series - "The Only Constant is Change: Bespoke Changepoint Modelling in PyMC" [[Link](https://discourse.pymc.io/t/new-pymcon-talk-the-only-constant-is-change-bespoke-changepoint-modelling-in-pymc-by-abuzar-mahmood/13251)]
+---
 
-**ACCESS-CI Compute Grant**  
+**2023** — **Invited Talk**  
+PyMCon Web Series — "The Only Constant is Change: Bespoke Changepoint Modelling in PyMC" [[Link](https://discourse.pymc.io/t/new-pymcon-talk-the-only-constant-is-change-bespoke-changepoint-modelling-in-pymc-by-abuzar-mahmood/13251)]
+
+---
+
+**2023** — **ACCESS-CI Compute Grant**  
 Awarded ACCESS-CI Compute Grant BIO230103 as PI from NSF
 
-**Trainee Professional Development Award**  
+---
+
+**2023** — **Trainee Professional Development Award**  
 Society for Neuroscience
 
-**Publication**  
-Mahmood, A., Steindler, J., Germaine, H., Katz, D.B., "Coupled Dynamics of Stimulus-Evoked Gustatory Cortical and Basolateral Amygdalar Activity," Journal of Neuroscience, vol. 43, no. 3, pp. 386–404 [[Link](https://www.jneurosci.org/content/43/3/386.long)]
+---
+
+**2023** — **Publication**  
+Mahmood, A., Steindler, J., Germaine, H., Katz, D.B., "Coupled Dynamics of Stimulus-Evoked Gustatory Cortical and Basolateral Amygdalar Activity," *Journal of Neuroscience*, vol. 43, no. 3, pp. 386–404 [[Link](https://www.jneurosci.org/content/43/3/386.long)]
+
+---
 
 ## Publications in Review/Submission
 

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -87,7 +87,7 @@ Vincent absolutely crushed his thesis defense and earned High Honors — what an
 ---
 
 **2024** — 🏅 **Polak Young Investigator Award**  
-Honored to receive the Polak Young Investigator Award from the Association for Chemoreception Sciences and to deliver the award lecture at the ACHEMS Annual Meeting!
+Honored to receive the Polak Young Investigator Award from the Association for Chemoreception Sciences and to deliver the award lecture at the ACHEMS Annual Meeting! And doubly honored to have been presented the award by none other that Dr. Alfredo Fontanini!
 
 <div style="display: flex; gap: 15px; margin: 25px 0; flex-wrap: wrap; justify-content: center; align-items: flex-start;">
   <img src="/images/news/polak_award_2024/polak_award.jpg" alt="Polak Young Investigator Award 2024" style="height: 350px; width: auto; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -9,7 +9,7 @@ author_profile: true
 
 # Latest Updates and Announcements
 
-Stay informed about my latest research developments, publications, presentations, and professional milestones.
+Exciting things are happening! Follow along for the latest on publications, awards, talks, and lab milestones.
 
 ## Recent Highlights
 
@@ -17,24 +17,15 @@ Stay informed about my latest research developments, publications, presentations
 
 ---
 
-**April 22, 2026** — **Publication**  
-Mukadam, N., Mahmood, A., Cronin-Golomb, A., DeGutis, J. (2026). Subjective Cognitive Concerns and Global Metacognitive Bias in Prodromal Parkinson's and Parkinson's Disease without Cognitive Impairment. *Neuropsychology*. Epub ahead of print. [[Link](https://doi.org/10.1037/neu0001083)]
+**April 22, 2026** — 🎉 **New Publication!**  
+Another one! Mukadam, N., Mahmood, A., Cronin-Golomb, A., DeGutis, J. (2026). Subjective Cognitive Concerns and Global Metacognitive Bias in Prodromal Parkinson's and Parkinson's Disease without Cognitive Impairment. *Neuropsychology*. Epub ahead of print. [[Link](https://doi.org/10.1037/neu0001083)]
 
 ---
 
-**February 11, 2026** — **Publications**  
-Two additional publications released in 2026:
+**February 11, 2026** — 🚀 **Two More Publications!**  
+2026 is off to a blazing start — two more papers out:
 - Mahmood, Abuzar, et al. "Sensory and Palatability Coding of Taste Stimuli in Cortex Involves Dynamic and Asymmetric Cortico-Amygdalar Interactions." *Journal of Neurophysiology*, Jan. 2026, p. jn.00503.2025. [[Link](https://doi.org/10.1152/jn.00503.2025)]
 - Mahmood, A. (2026). pytau: A Python package for streamlined changepoint model analysis in neuroscience. *Journal of Open Source Software*, 11(117), 8509. [[Link](https://doi.org/10.21105/joss.08509)]
-
----
-
-**January 18, 2026** — **Vincent Defense**  
-Vincent successfully defended his thesis and received High Honors for his defense work. He will be going on to do a post-bac in Angela Langdon's lab at the NIMH. [[NIMH Lab Link](https://www.nimh.nih.gov/research/research-conducted-at-nimh/principal-investigators/angela-langdon-phd)] Congrats Vincent!!
-
-<div style="display: flex; gap: 15px; margin: 25px 0; flex-wrap: wrap; justify-content: center; align-items: flex-start;">
-  <img src="/images/news/vincent_defense_2025/vincent_defense.jpg" alt="Vincent Defense 2025" style="height: 350px; width: auto; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
-</div>
 
 ---
 
@@ -42,20 +33,20 @@ Vincent successfully defended his thesis and received High Honors for his defens
 
 ---
 
-**December 2, 2025** — **New Preprints**  
-Two new preprints posted on bioRxiv:
+**December 2, 2025** — 📄 **New Preprints on bioRxiv**  
+Two new preprints are up — check them out!
 - Mahmood A, Steindler JR, Katz DB (2025) "Sensory and palatability coding of taste stimuli in cortex involves dynamic and asymmetric cortico-amygdalar interactions" [[Link](https://doi.org/10.1101/2025.07.01.662567)]
 - Baas-Thomas N, Mahmood A, Mukherjee N, Maigler KC, Wang Y, Katz DB (2025) "The Ingestive Response Reflects Neural Dynamics in Gustatory Cortex" [[Link](https://doi.org/10.1101/2025.10.01.679845)]
 
 ---
 
-**October 14, 2025** — **Collaboration Featured in AChemS Career Networking Seminar**  
-Thomas Gray (Brandeis University) presented work from our collaboration on retronasal odor processing in gustatory cortex at the AChemS Career Networking Seminar Series. The talk, titled "Neural and behavioral correlates of flavor perception," explored how retronasal odor is processed in the gustatory cortex, its influence on taste responses, and how flavor experiences shape odor preferences.
+**October 14, 2025** — 🎙️ **Collaboration Spotlighted at AChemS Career Networking Seminar**  
+Our collaborative work got some well-deserved attention! Thomas Gray (Brandeis University) presented research from our collaboration on retronasal odor processing in gustatory cortex at the AChemS Career Networking Seminar Series. The talk, "Neural and behavioral correlates of flavor perception," dove into how retronasal odor is processed in gustatory cortex, its influence on taste responses, and how flavor experiences shape odor preferences.
 
 ---
 
-**October 9, 2025** — **Poster of Distinction**  
-Received Poster of Distinction award at MCRI Annual Retreat 2025
+**October 9, 2025** — 🏆 **Poster of Distinction at MCRI Annual Retreat!**  
+Thrilled to have received the Poster of Distinction award at the MCRI Annual Retreat 2025!
 
 <div style="display: flex; gap: 15px; margin: 25px 0; flex-wrap: wrap; justify-content: center; align-items: flex-start;">
   <img src="/images/news/mcri_retreat_2025/WhatsApp Image 2025-10-09 at 5.05.40 PM.jpeg" alt="MCRI Retreat 2025 - Poster Presentation" style="height: 350px; width: auto; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
@@ -64,20 +55,30 @@ Received Poster of Distinction award at MCRI Annual Retreat 2025
 
 ---
 
-**October 9, 2025** — **ACCESS-CI Compute Grant**  
-Awarded ACCESS-CI Compute Grant MED250058 (CoPI) from NSF for computational research
+**October 9, 2025** — 💻 **NSF Compute Grant Awarded**  
+Excited to receive the ACCESS-CI Compute Grant MED250058 (CoPI) from NSF — more computational power for bigger science!
 
 ---
 
-**October 9, 2025** — **Invited Talks**  
+**October 9, 2025** — 🎤 **Invited Talks**  
+Had a great time sharing our work at three venues:
 - Mathematical Biology Seminar, Brandeis University
 - Insights Team Meeting, Appcast Inc.
 - Systems Neuroscience Journal Club, Harvard Medical School
 
 ---
 
-**October 9, 2025** — **Guest Lecturer**  
-Advanced Data Analysis course, Brandeis University — LLMs and AI Agent pipelines
+**October 9, 2025** — 🧑‍🏫 **Guest Lecturer**  
+Taught a session on LLMs and AI Agent pipelines for the Advanced Data Analysis course at Brandeis University — always fun to bring cutting-edge tools into the classroom!
+
+---
+
+**May 1, 2025** — 🎓 **Congratulations, Vincent!**  
+Vincent absolutely crushed his thesis defense and earned High Honors — what an achievement! He's heading off to do a post-bac in Angela Langdon's lab at the NIMH. The future is bright for this one! [[NIMH Lab Link](https://www.nimh.nih.gov/research/research-conducted-at-nimh/principal-investigators/angela-langdon-phd)]
+
+<div style="display: flex; gap: 15px; margin: 25px 0; flex-wrap: wrap; justify-content: center; align-items: flex-start;">
+  <img src="/images/news/vincent_defense_2025/vincent_defense.jpg" alt="Vincent Defense 2025" style="height: 350px; width: auto; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
+</div>
 
 ---
 
@@ -85,8 +86,8 @@ Advanced Data Analysis course, Brandeis University — LLMs and AI Agent pipelin
 
 ---
 
-**2024** — **Polak Young Investigator Award**  
-Received Polak Young Investigator Award from Association for Chemoreception Sciences, delivered award lecture at ACHEMS Annual Meeting
+**2024** — 🏅 **Polak Young Investigator Award**  
+Honored to receive the Polak Young Investigator Award from the Association for Chemoreception Sciences and to deliver the award lecture at the ACHEMS Annual Meeting!
 
 <div style="display: flex; gap: 15px; margin: 25px 0; flex-wrap: wrap; justify-content: center; align-items: flex-start;">
   <img src="/images/news/polak_award_2024/polak_award.jpg" alt="Polak Young Investigator Award 2024" style="height: 350px; width: auto; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
@@ -94,14 +95,15 @@ Received Polak Young Investigator Award from Association for Chemoreception Scie
 
 ---
 
-**2024** — **Invited Presentations**  
+**2024** — 🎤 **Invited Presentations**  
+Presented at two exciting venues:
 - Swartz Foundation Annual Meeting
 - Brandeis Neuro Postdoc Symposium
 
 ---
 
-**2024** — **Computational Neuroscience Fellowship**  
-Awarded Computational Neuroscience Fellowship from Swartz Foundation (2023–present)
+**2024** — 🧠 **Computational Neuroscience Fellowship**  
+Awarded the Computational Neuroscience Fellowship from the Swartz Foundation (2023–present) — grateful for the support to push the boundaries of computational approaches in neuroscience!
 
 ---
 
@@ -109,35 +111,35 @@ Awarded Computational Neuroscience Fellowship from Swartz Foundation (2023–pre
 
 ---
 
-**2023** — **Ph.D. Completion**  
-Completed Ph.D. in Neuroscience at Brandeis University  
-Thesis: "Multi-region Coordination for Taste Processing in the Rodent Brain" [[PDF](/files/Mahmood_Dissertation_Brandeis_2_10_23.pdf)]  
+**2023** — 🎓 **Ph.D. Complete!**  
+Officially a Doctor of Neuroscience! Completed my Ph.D. at Brandeis University with the thesis "Multi-region Coordination for Taste Processing in the Rodent Brain." [[PDF](/files/Mahmood_Dissertation_Brandeis_2_10_23.pdf)]  
 Advisor: Donald B. Katz
 
 ---
 
-**2023** — **Postdoctoral Positions**  
+**2023** — 🔬 **Postdoctoral Positions**  
+Excited to continue the science in two postdoctoral roles:
 - Postdoctoral Research Fellow, Tufts Medical Center
 - Postdoctoral Fellow, Brandeis University
 
 ---
 
-**2023** — **Invited Talk**  
-PyMCon Web Series — "The Only Constant is Change: Bespoke Changepoint Modelling in PyMC" [[Link](https://discourse.pymc.io/t/new-pymcon-talk-the-only-constant-is-change-bespoke-changepoint-modelling-in-pymc-by-abuzar-mahmood/13251)]
+**2023** — 🎙️ **Invited Talk — PyMCon Web Series**  
+Gave a talk at the PyMCon Web Series: "The Only Constant is Change: Bespoke Changepoint Modelling in PyMC" [[Link](https://discourse.pymc.io/t/new-pymcon-talk-the-only-constant-is-change-bespoke-changepoint-modelling-in-pymc-by-abuzar-mahmood/13251)]
 
 ---
 
-**2023** — **ACCESS-CI Compute Grant**  
-Awarded ACCESS-CI Compute Grant BIO230103 as PI from NSF
+**2023** — 💻 **NSF Compute Grant Awarded**  
+Awarded ACCESS-CI Compute Grant BIO230103 as PI from NSF — fueling large-scale neural data analysis!
 
 ---
 
-**2023** — **Trainee Professional Development Award**  
-Society for Neuroscience
+**2023** — 🏆 **Trainee Professional Development Award**  
+Received the Trainee Professional Development Award from the Society for Neuroscience.
 
 ---
 
-**2023** — **Publication**  
+**2023** — 📄 **Publication**  
 Mahmood, A., Steindler, J., Germaine, H., Katz, D.B., "Coupled Dynamics of Stimulus-Evoked Gustatory Cortical and Basolateral Amygdalar Activity," *Journal of Neuroscience*, vol. 43, no. 3, pp. 386–404 [[Link](https://www.jneurosci.org/content/43/3/386.long)]
 
 ---


### PR DESCRIPTION
Closes #110

Each news item now displays the date it was posted, sourced from the git commit history for `_pages/news.md`. Entries are separated by horizontal rules to visually distinguish individual posts.